### PR TITLE
Bot-posted and bot-editable messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,6 +1,8 @@
 import sys
 
 import discord
+from discord import option
+
 import yaml
 import logging
 
@@ -74,9 +76,11 @@ async def message_count_other(ctx, käyttäjä: discord.Option(discord.SlashComm
     await mybot.message_count_other_command(ctx, käyttäjä)
     pass
 
-@bot.slash_command(name="post-copy", description="Tekee toisen käyttäjän viestistä kopion, jonka julkaisee kohdekanavalla")
-async def post_copy(ctx, kanava: discord.Option(discord.SlashCommandOptionType.channel), viesti_viittaus): # "kanava" and "viesti_viittaus" are in Finnish because they're visible in command context help
-    await mybot.post_copy(ctx, kanava, viesti_viittaus)
+@bot.slash_command(name="post-copy", description="Tekee lähdeviestistä kopion, jonka botti julkaisee annetulla kanavalla.")
+@option("kanava", discord.SlashCommandOptionType.channel, description="Kanava, jonne viesti kopioidaan")
+@option("lähdeviesti", str, description="Kopioitava viesti, täysi URL tai kanavan sisäisesti Message ID")
+async def post_copy(ctx, kanava, lähdeviesti): # "kanava" and "lähdeviesti" are in Finnish because they're visible in command context help
+    await mybot.post_copy(ctx, kanava, lähdeviesti)
     pass
 
 bot.run(cfg["token"])

--- a/bot.py
+++ b/bot.py
@@ -83,4 +83,12 @@ async def post_copy(ctx, kanava, lähdeviesti): # "kanava" and "lähdeviesti" ar
     await mybot.post_copy(ctx, kanava, lähdeviesti)
     pass
 
+@bot.slash_command(name="post-edit",
+    description="Muokkaa kohdeviestiä kopioimalla sen tilalle lähdeviestin sisältö. Kohdeviestin oltava botin oma.")
+@option("kohdeviesti", str, description="Muokattava viesti, täysi URL tai kanavan sisäisesti Message ID")
+@option("lähdeviesti", str, description="Kopioitava viesti, täysi URL tai kanavan sisäisesti Message ID")
+async def post_edit(ctx, kohdeviesti, lähdeviesti):
+    await mybot.post_edit(ctx, kohdeviesti, lähdeviesti)
+    pass
+
 bot.run(cfg["token"])

--- a/bot.py
+++ b/bot.py
@@ -74,4 +74,9 @@ async def message_count_other(ctx, käyttäjä: discord.Option(discord.SlashComm
     await mybot.message_count_other_command(ctx, käyttäjä)
     pass
 
+@bot.slash_command(name="post-copy", description="Tekee toisen käyttäjän viestistä kopion, jonka julkaisee kohdekanavalla")
+async def post_copy(ctx, kanava: discord.Option(discord.SlashCommandOptionType.channel), viesti_viittaus): # "kanava" and "viesti_viittaus" are in Finnish because they're visible in command context help
+    await mybot.post_copy(ctx, channel, message)
+    pass
+
 bot.run(cfg["token"])

--- a/bot.py
+++ b/bot.py
@@ -76,7 +76,7 @@ async def message_count_other(ctx, käyttäjä: discord.Option(discord.SlashComm
 
 @bot.slash_command(name="post-copy", description="Tekee toisen käyttäjän viestistä kopion, jonka julkaisee kohdekanavalla")
 async def post_copy(ctx, kanava: discord.Option(discord.SlashCommandOptionType.channel), viesti_viittaus): # "kanava" and "viesti_viittaus" are in Finnish because they're visible in command context help
-    await mybot.post_copy(ctx, channel, message)
+    await mybot.post_copy(ctx, kanava, viesti_viittaus)
     pass
 
 bot.run(cfg["token"])

--- a/messages.py
+++ b/messages.py
@@ -1,0 +1,58 @@
+import logging
+
+# Returns a tuple (message_id, context_id), where context_id can be -1
+def parse_message_reference(message_reference):
+    message_str = ""
+    context_str = None
+
+    # parse ID from URI or use it directly if not an URI
+    slash_index = message_reference.rfind('/')
+    if slash_index >= 0:
+        message_str = message_reference[slash_index+1:]
+        context_str = message_reference[:slash_index]
+        slash_index_r2 = context_str.rfind('/')
+        context_str = message_reference[slash_index_r2+1:slash_index]
+    else:
+        message_str = message_reference
+
+    message_id = -1
+    context_id = -1
+
+    # parse IDs into an integers and handle error if thrown
+    try:
+        message_id = int(message_str)
+        if context_str != None:
+            context_id = int(context_str)
+    except ValueError:
+        pass
+
+    return (message_id, context_id)
+
+# Can fetch a message from anywhere, or within context if reference is merely a Message ID
+# returns a tuple (message, error_message) where latter is not None if message is None
+async def fetch_message_by_reference(self, ctx, message_reference):
+    ids = parse_message_reference(message_reference)
+
+    message_id = ids[0]
+    if message_id == -1:
+        return (None, "Virheellinen viittaus kopioitavaan viestiin '{}'.".format(message_reference))
+
+    context_id = ids[1]
+    if context_id == -1:
+        return await fetch_message_by_id(ctx, message_id)
+
+    new_context = self.api.get_guild(self.guild_id).get_channel_or_thread(context_id)
+    if new_context == None:
+        return (None, "Virheellinen viittaus kanavaan tai ketjuun '{}'->'{}'".format(message_reference, context_id))
+
+    return await fetch_message_by_id(new_context, message_id)
+
+# Can fetch a message by ID, but only within limited context (like the channel where command was given)
+# returns a tuple (message, error_message) where latter is not None if message is None
+async def fetch_message_by_id(ctx, message_id):
+    try:
+        message = await ctx.fetch_message(message_id)
+    except Exception as e:
+        return (None, "Viestin {} hakeminen epäonnistui, virhe: '{}'".format(message_id, str(e)))
+
+    return (message, None)

--- a/mybot.py
+++ b/mybot.py
@@ -336,9 +336,9 @@ class MyBot:
             await ctx.send_response(content=fetch_result[1], ephemeral=True)
             return
 
-        await channel.send(fetch_result[1].content)
+        await channel.send(fetch_result[0].content)
         await ctx.send_response(
-            content="Viestin {} kopioiminen onnistui".format(fetch_result[1].id),
+            content="Viestin {} kopioiminen onnistui".format(fetch_result[0].id),
             ephemeral=True)
 
     # can raise NotFound, Forbidden or HTTPException

--- a/mybot.py
+++ b/mybot.py
@@ -358,7 +358,7 @@ class MyBot:
             return
 
         text = message.content
-        await message.channel.send(text)
+        await channel.send(text)
         
     async def midnight_winners_command(self, ctx):
         with self.connection_pool.get_connection() as conn:

--- a/mybot.py
+++ b/mybot.py
@@ -345,7 +345,7 @@ class MyBot:
             id = int(message_id)
         except ValueError:
             await ctx.send_response(
-                content="Virheellinen viittaus kopioitavaan viestiin {message_reference}->{message_id}.",
+                content="Virheellinen viittaus kopioitavaan viestiin {}->{}.".format(message_reference, message_id),
                 ephemeral=True)
             return
 
@@ -353,12 +353,15 @@ class MyBot:
             message = await ctx.fetch_message(id)
         except Exception as e:
             await ctx.send_response(
-                content="Viestin {message_id} hakeminen epäonnistui, virhe: '{e}'",
+                content="Viestin {} hakeminen epäonnistui, virhe: '{}'".format(message_id, str(e)),
                 ephemeral=True)
             return
 
         text = message.content
         await channel.send(text)
+        await ctx.send_response(
+            content="Viestin {} kopioiminen onnistui".format(message_id),
+            ephemeral=True)
         
     async def midnight_winners_command(self, ctx):
         with self.connection_pool.get_connection() as conn:

--- a/mybot.py
+++ b/mybot.py
@@ -336,9 +336,9 @@ class MyBot:
             await ctx.send_response(content=fetch_result[1], ephemeral=True)
             return
 
-        await channel.send(fetch_result[0].content)
+        new_msg = await channel.send(fetch_result[0].content)
         await ctx.send_response(
-            content="Viestin {} kopioiminen onnistui".format(fetch_result[0].id),
+            content="Viestin {} kopioiminen onnistui, uusi viesti: {}".format(message_reference, new_msg.jump_url),
             ephemeral=True)
 
     # can raise NotFound, Forbidden or HTTPException
@@ -356,7 +356,7 @@ class MyBot:
 
         await fetch_target_result[0].edit(fetch_source_result[0].content)
         await ctx.send_response(
-            content="Viestin {} päivittäminen onnistui".format(fetch_target_result[0].id),
+            content="Viestin {} päivittäminen onnistui".format(fetch_target_result[0].jump_url),
             ephemeral=True)
         
     async def midnight_winners_command(self, ctx):


### PR DESCRIPTION
Added slash commands **post-copy** and **post-edit** with full descriptions (see @option() used in bot.py) for typed command arguments.

- post-copy can copy a source message's content into a bot-posted message in target channel
- post-edit can update a bot-posted message to match the content of referenced source message

Both commands can use full message URL to reference a message on any channel or thread, or just a message ID if searching within the channel where the command is given.